### PR TITLE
Don't throw exceptions on errors, return {:error, :reason} instead

### DIFF
--- a/test/connection_errors_test.exs
+++ b/test/connection_errors_test.exs
@@ -1,0 +1,54 @@
+defmodule CastorEDCTest.ConnectionErrors do
+  use ExUnit.Case, async: true
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  import CastorEDC
+
+  @client CastorEDC.Client.access_token("supersecretaccesstoken")
+
+  # These tests verify that we will return `{:error, :reason}` tuples on
+  # non-HTTP related errors, like timeouts and refused connetions.
+  #
+  # In reality, :reason is an atom (at least with Hackney, this may be
+  # adapter-specific behavior?), however due to a quirk in ExVCR these atoms
+  # are converted to strings on save:
+  #
+  # https://github.com/parroty/exvcr/blob/69aaa49c83de34814dc66253e5819583077cf145/lib/exvcr/adapter/hackney/converter.ex#L96-L101
+  #
+  # ..but not converted back from string to atom on load/restore:
+  #
+  # https://github.com/parroty/exvcr/blob/69aaa49c83de34814dc66253e5819583077cf145/lib/exvcr/adapter/hackney/converter.ex#L8-L21
+  #
+  # As such these tests pattern-match on strings while in reality, end-users
+  # should pattern-match on atoms.
+
+  test "get" do
+    use_cassette "errors/get" do
+      {:error, "econnrefused"} = get("api/", @client)
+    end
+  end
+
+  test "post" do
+    use_cassette "errors/post" do
+      {:error, "econnrefused"} = post("api/", @client, %{})
+    end
+  end
+
+  test "patch" do
+    use_cassette "errors/patch" do
+      {:error, "econnrefused"} = patch("api/", @client, %{})
+    end
+  end
+
+  test "authenticate" do
+    use_cassette "errors/authenticate" do
+      client =
+        CastorEDC.Client.new(
+          "0b362196-09ad-4d09-b5bf-27a515bbc358",
+          "secret"
+        )
+
+      {:error, "econnrefused"} = CastorEDC.authenticate(client)
+    end
+  end
+end

--- a/test/fixture/vcr_cassettes/errors/authenticate.json
+++ b/test/fixture/vcr_cassettes/errors/authenticate.json
@@ -1,0 +1,21 @@
+[
+  {
+    "request": {
+      "body": "client_id=0b362196-09ad-4d09-b5bf-27a515bbc358&client_secret=secret&grant_type=client_credentials&scope=default",
+      "headers": {
+        "content-type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://data.castoredc.com/oauth/token"
+    },
+    "response": {
+      "binary": false,
+      "body": "econnrefused",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/errors/get.json
+++ b/test/fixture/vcr_cassettes/errors/get.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "Bearer supersecretaccesstoken",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://data.castoredc.com/api/"
+    },
+    "response": {
+      "binary": false,
+      "body": "econnrefused",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/errors/patch.json
+++ b/test/fixture/vcr_cassettes/errors/patch.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "{}",
+      "headers": {
+        "content-type": "application/json",
+        "authorization": "Bearer supersecretaccesstoken",
+        "Accept": "application/json"
+      },
+      "method": "patch",
+      "options": [],
+      "request_body": "",
+      "url": "https://data.castoredc.com/api/"
+    },
+    "response": {
+      "binary": false,
+      "body": "econnrefused",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/errors/post.json
+++ b/test/fixture/vcr_cassettes/errors/post.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "{}",
+      "headers": {
+        "content-type": "application/json",
+        "authorization": "Bearer supersecretaccesstoken",
+        "Accept": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://data.castoredc.com/api/"
+    },
+    "response": {
+      "binary": false,
+      "body": "econnrefused",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]


### PR DESCRIPTION
This unifies error responses to use the `{:error, :reason}` pattern on non-HTTP errors like timeouts and refused connections. The primarily benefit of this is that it allows users to pattern-match on all possible error cases, rather than having to pattern match on the HTTP status code as well having to handle exceptions to cover all possible error cases.

In short, it simplifies error handling by allowing:

```elixir
case CastorEDC.Common.Studies.list(client) do
  {200, %{"_embedded" => %{"study" => studies}}} ->
    # use studies
  {errorcode, detail} ->
    # handle API response error
  {:error, reason} ->
    # handle connection error
end
```

This relates to #16.